### PR TITLE
feat(KUI-1463): add enpoints for sereparing of analyses depending of source

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Only admin pages may change API data while public pages can only read. Therefore
 ### Connected Projects
 
 - [kursutveckling-web](https://github.com/KTH/kursinfo-web)
-*- [kursutveckling-admin-web](https://github.com/KTH/kursinfo-admin-web) (Discontinued in March 2025)*
+- *~~[kursutveckling-admin-web](https://github.com/KTH/kursinfo-admin-web)~~ (Discontinued in March 2025)*
 - [kursutveckling-integration-api](https://github.com/KTH/ursutveckling-integration-api)
 
 ### Related Projects

--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ Kursutveckling-api is a microservice to save course's analyses data to database,
 
 It uses [Node.js](https://nodejs.org/), [Mongoose](https://mongoosejs.com/), `kth-node-mongo`, and is based on [node-api](https://github.com/KTH/node-api).
 
+*Please note!* 
+
+*In March 2025, the tool "Kursanalys och kursdata"([kursutveckling-admin-web](https://github.com/KTH/kursutveckling-admin-web)) for publishing and editing course analysis and course data will be discontinued. Last use is for courses taken during study period 2 in Autumn 2024. From study period 3 in Spring 2025, course analysis is filled in and published in Canvas. The integration function ([kursutveckling-integration-api](https://github.com/KTH/kursutveckling-integration-api)) fetches and populates from then on the database with analysis data used by this repo's api `kursutveckling-api`.*
+
 ### 🏠 [Homepage](https://github.com/KTH/kursutveckling-api)
 
 ## Overview
@@ -25,7 +29,8 @@ Only admin pages may change API data while public pages can only read. Therefore
 ### Connected Projects
 
 - [kursutveckling-web](https://github.com/KTH/kursinfo-web)
-- [kursutveckling-admin-web](https://github.com/KTH/kursinfo-admin-web)
+*- [kursutveckling-admin-web](https://github.com/KTH/kursinfo-admin-web) (Discontinued in March 2025)*
+- [kursutveckling-integration-api](https://github.com/KTH/ursutveckling-integration-api)
 
 ### Related Projects
 

--- a/server/controllers/roundAnalysisCtrl.js
+++ b/server/controllers/roundAnalysisCtrl.js
@@ -197,7 +197,7 @@ async function getCanvasAnalysisListByCourseCode(req, res, next) {
   const courseCode = req.params.courseCode.toUpperCase()
   let dbResponse
   try {
-    dbResponse = await db.fetchAllCanvasRoundAnalysesByCourseCode(courseCode)
+    dbResponse = await db.fetchPublishedCanvasRoundAnalysesByCourseCode(courseCode)
     log.debug('Successfully got all analyses for', { courseCode, dbResponse })
     res.json(dbResponse)
   } catch (err) {
@@ -206,15 +206,15 @@ async function getCanvasAnalysisListByCourseCode(req, res, next) {
   }
 }
 
-async function getKursinfoadminAnalysisListByCourseCode(req, res, next) {
+async function getAdminWebAnalysisListByCourseCode(req, res, next) {
   const courseCode = req.params.courseCode.toUpperCase()
   let dbResponse
   try {
-    dbResponse = await db.fetchAllKursinfoadminRoundAnalysesByCourseCode(courseCode)
+    dbResponse = await db.fetchPublishedAdminWebRoundAnalysesByCourseCode(courseCode)
     log.debug('Successfully got all analyses for', { courseCode, dbResponse })
     res.json(dbResponse)
   } catch (err) {
-    log.error('Error in getKursinfoadminAnalysisListByCourseCode', { error: err })
+    log.error('Error in getAdminWebAnalysisListByCourseCode', { error: err })
     next(err)
   }
 }
@@ -229,5 +229,5 @@ module.exports = {
   getCourseAnalysesForSemestersList,
   getUsedRounds,
   getCanvasAnalysisListByCourseCode,
-  getKursinfoadminAnalysisListByCourseCode,
+  getAdminWebAnalysisListByCourseCode,
 }

--- a/server/controllers/roundAnalysisCtrl.js
+++ b/server/controllers/roundAnalysisCtrl.js
@@ -193,6 +193,32 @@ async function getUsedRounds(req, res, next) {
   }
 }
 
+async function getCanvasAnalysisListByCourseCode(req, res, next) {
+  const courseCode = req.params.courseCode.toUpperCase()
+  let dbResponse
+  try {
+    dbResponse = await db.fetchAllCanvasRoundAnalysesByCourseCode(courseCode)
+    log.debug('Successfully got all analyses for', { courseCode, dbResponse })
+    res.json(dbResponse)
+  } catch (err) {
+    log.error('Error in getCanvasAnalysisListByCourseCode', { error: err })
+    next(err)
+  }
+}
+
+async function getKursinfoadminAnalysisListByCourseCode(req, res, next) {
+  const courseCode = req.params.courseCode.toUpperCase()
+  let dbResponse
+  try {
+    dbResponse = await db.fetchAllKursinfoadminRoundAnalysesByCourseCode(courseCode)
+    log.debug('Successfully got all analyses for', { courseCode, dbResponse })
+    res.json(dbResponse)
+  } catch (err) {
+    log.error('Error in getKursinfoadminAnalysisListByCourseCode', { error: err })
+    next(err)
+  }
+}
+
 module.exports = {
   getAnalysis: getRoundAnalysis,
   postAnalysis: postRoundAnalysis,
@@ -202,4 +228,6 @@ module.exports = {
   getCourseAnalyses,
   getCourseAnalysesForSemestersList,
   getUsedRounds,
+  getCanvasAnalysisListByCourseCode,
+  getKursinfoadminAnalysisListByCourseCode,
 }

--- a/server/controllers/roundAnalysisCtrl.js
+++ b/server/controllers/roundAnalysisCtrl.js
@@ -194,10 +194,10 @@ async function getUsedRounds(req, res, next) {
 }
 
 async function getCanvasAnalysisListByCourseCode(req, res, next) {
-  const courseCode = req.params.courseCode.toUpperCase()
+  const { courseCode } = req.params
   let dbResponse
   try {
-    dbResponse = await db.fetchPublishedCanvasRoundAnalysesByCourseCode(courseCode)
+    dbResponse = await db.fetchPublishedCanvasRoundAnalysesByCourseCode(courseCode.toUpperCase())
     log.debug('Successfully got all analyses for', { courseCode, dbResponse })
     res.json(dbResponse)
   } catch (err) {
@@ -207,10 +207,10 @@ async function getCanvasAnalysisListByCourseCode(req, res, next) {
 }
 
 async function getAdminWebAnalysisListByCourseCode(req, res, next) {
-  const courseCode = req.params.courseCode.toUpperCase()
+  const { courseCode } = req.params
   let dbResponse
   try {
-    dbResponse = await db.fetchPublishedAdminWebRoundAnalysesByCourseCode(courseCode)
+    dbResponse = await db.fetchPublishedAdminWebRoundAnalysesByCourseCode(courseCode.toUpperCase())
     log.debug('Successfully got all analyses for', { courseCode, dbResponse })
     res.json(dbResponse)
   } catch (err) {

--- a/server/lib/database.js
+++ b/server/lib/database.js
@@ -49,13 +49,13 @@ function fetchAllPublishedRoundAnalysisBySemester(semester) {
 
 function fetchPublishedCanvasRoundAnalysesByCourseCode(courseCode) {
   if (!courseCode) throw new Error('courseCode must be set')
-  log.debug('Fetching all round analyses for ' + courseCode + ' from Canvas')
+  log.debug('Fetching published round analyses for ' + courseCode + ' from Canvas')
   return RoundAnalysis.aggregate([{ $match: { courseCode, analysisType: 'canvas' } }])
 }
 
 function fetchPublishedAdminWebRoundAnalysesByCourseCode(courseCode) {
   if (!courseCode) throw new Error('courseCode must be set')
-  log.debug('Fetching all round analyses for ' + courseCode + ' from AdminWeb')
+  log.debug('Fetching published round analyses for ' + courseCode + ' from AdminWeb')
   return RoundAnalysis.aggregate([{ $match: { courseCode, isPublished: true, analysisType: { $ne: 'canvas' } } }])
 }
 

--- a/server/lib/database.js
+++ b/server/lib/database.js
@@ -47,16 +47,16 @@ function fetchAllPublishedRoundAnalysisBySemester(semester) {
   return RoundAnalysis.aggregate([{ $match: { semester, isPublished: true } }])
 }
 
-function fetchAllCanvasRoundAnalysesByCourseCode(courseCode) {
+function fetchPublishedCanvasRoundAnalysesByCourseCode(courseCode) {
   if (!courseCode) throw new Error('courseCode must be set')
   log.debug('Fetching all round analyses for ' + courseCode + ' from Canvas')
-  return RoundAnalysis.aggregate([{ $match: { courseCode, isPublished: null, gradingDistribution: { $ne: null } } }])
+  return RoundAnalysis.aggregate([{ $match: { courseCode, analysisType: 'canvas' } }])
 }
 
-function fetchAllKursinfoadminRoundAnalysesByCourseCode(courseCode) {
+function fetchPublishedAdminWebRoundAnalysesByCourseCode(courseCode) {
   if (!courseCode) throw new Error('courseCode must be set')
-  log.debug('Fetching all round analyses for ' + courseCode + ' from Kursinfoadmin')
-  return RoundAnalysis.aggregate([{ $match: { courseCode, isPublished: true, examinationGrade: { $ne: null } } }])
+  log.debug('Fetching all round analyses for ' + courseCode + ' from AdminWeb')
+  return RoundAnalysis.aggregate([{ $match: { courseCode, isPublished: true, analysisType: { $ne: 'canvas' } } }])
 }
 
 module.exports = {
@@ -67,6 +67,6 @@ module.exports = {
   fetchAllRoundAnalysisByCourseCode,
   fetchAllRoundAnalysisByCourseCodeAndSemester,
   fetchAllPublishedRoundAnalysisBySemester,
-  fetchAllCanvasRoundAnalysesByCourseCode,
-  fetchAllKursinfoadminRoundAnalysesByCourseCode,
+  fetchPublishedCanvasRoundAnalysesByCourseCode,
+  fetchPublishedAdminWebRoundAnalysesByCourseCode,
 }

--- a/server/lib/database.js
+++ b/server/lib/database.js
@@ -47,6 +47,18 @@ function fetchAllPublishedRoundAnalysisBySemester(semester) {
   return RoundAnalysis.aggregate([{ $match: { semester, isPublished: true } }])
 }
 
+function fetchAllCanvasRoundAnalysesByCourseCode(courseCode) {
+  if (!courseCode) throw new Error('courseCode must be set')
+  log.debug('Fetching all round analyses for ' + courseCode + ' from Canvas')
+  return RoundAnalysis.aggregate([{ $match: { courseCode, isPublished: null, gradingDistribution: { $ne: null } } }])
+}
+
+function fetchAllKursinfoadminRoundAnalysesByCourseCode(courseCode) {
+  if (!courseCode) throw new Error('courseCode must be set')
+  log.debug('Fetching all round analyses for ' + courseCode + ' from Kursinfoadmin')
+  return RoundAnalysis.aggregate([{ $match: { courseCode, isPublished: true, examinationGrade: { $ne: null } } }])
+}
+
 module.exports = {
   fetchRoundAnalysisById,
   storeRoundAnalysis,
@@ -55,4 +67,6 @@ module.exports = {
   fetchAllRoundAnalysisByCourseCode,
   fetchAllRoundAnalysisByCourseCodeAndSemester,
   fetchAllPublishedRoundAnalysisBySemester,
+  fetchAllCanvasRoundAnalysesByCourseCode,
+  fetchAllKursinfoadminRoundAnalysesByCourseCode,
 }

--- a/server/server.js
+++ b/server/server.js
@@ -140,10 +140,7 @@ apiRoute.register(paths.api.getAnalysisListByCourseCode, RoundAnalysis.getAnalys
 apiRoute.register(paths.api.getCourseAnalysesForSemester, RoundAnalysis.getCourseAnalyses)
 
 apiRoute.register(paths.api.getCanvasAnalysisListByCourseCode, RoundAnalysis.getCanvasAnalysisListByCourseCode)
-apiRoute.register(
-  paths.api.getKursinfoadminAnalysisListByCourseCode,
-  RoundAnalysis.getKursinfoadminAnalysisListByCourseCode
-)
+apiRoute.register(paths.api.getAdminWebAnalysisListByCourseCode, RoundAnalysis.getAdminWebAnalysisListByCourseCode)
 
 // courseAnalysesForSemestersList
 apiRoute.register(paths.api.getCourseAnalysesForSemestersList, RoundAnalysis.getCourseAnalysesForSemestersList)

--- a/server/server.js
+++ b/server/server.js
@@ -138,6 +138,13 @@ apiRoute.register(paths.api.deleteCourseRoundAnalysisDataById, RoundAnalysis.del
 
 apiRoute.register(paths.api.getAnalysisListByCourseCode, RoundAnalysis.getAnalysisList)
 apiRoute.register(paths.api.getCourseAnalysesForSemester, RoundAnalysis.getCourseAnalyses)
+
+apiRoute.register(paths.api.getCanvasAnalysisListByCourseCode, RoundAnalysis.getCanvasAnalysisListByCourseCode)
+apiRoute.register(
+  paths.api.getKursinfoadminAnalysisListByCourseCode,
+  RoundAnalysis.getKursinfoadminAnalysisListByCourseCode
+)
+
 // courseAnalysesForSemestersList
 apiRoute.register(paths.api.getCourseAnalysesForSemestersList, RoundAnalysis.getCourseAnalysesForSemestersList)
 apiRoute.register(paths.api.getUsedRounds, RoundAnalysis.getUsedRounds)

--- a/swagger.json
+++ b/swagger.json
@@ -332,6 +332,78 @@
           }
         ]
       }
+    },
+    "/v1/canvasCourseAnalysisList/{courseCode}": {
+      "get": {
+        "operationId": "getCanvasAnalysisListByCourseCode",
+        "summary": "Get a list of analyses for a course",
+        "description": "Get a list of analyses for a course round published in Canvas",
+        "parameters": [
+          {
+            "name": "courseCode",
+            "in": "path",
+            "description": "Id of the course code",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "tags": ["v1"],
+        "responses": {
+          "200": {
+            "description": "Successfully got analyses for requested course code",
+            "schema": {
+              "$ref": "#/definitions/RoundAnalysisCanvas"
+            }
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        },
+        "security": [
+          {
+            "api_key": ["read"]
+          }
+        ]
+      }
+    },
+    "/v1/kursinfoadminCourseAnalysisList/{courseCode}": {
+      "get": {
+        "operationId": "getKursinfoadminAnalysisListByCourseCode",
+        "summary": "Get a list of analyses for a course",
+        "description": "Get a list of analyses for a course round published in Kursinfoadmin Tool",
+        "parameters": [
+          {
+            "name": "courseCode",
+            "in": "path",
+            "description": "Id of the course code",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "tags": ["v1"],
+        "responses": {
+          "200": {
+            "description": "Successfully got analyses for requested course code",
+            "schema": {
+              "$ref": "#/definitions/RoundAnalysis"
+            }
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        },
+        "security": [
+          {
+            "api_key": ["read"]
+          }
+        ]
+      }
     }
   },
   "securityDefinitions": {
@@ -505,6 +577,104 @@
         "semester": "20211",
         "syllabusStartTerm": "20211",
         "ugKeys": ["XYZ123.examiner", "XYZ123.20211.1.courseresponsible"]
+      }
+    },
+    "RoundAnalysisCanvas": {
+      "type": "object",
+      "required": ["courseCode"],
+      "properties": {
+        "alterationText": {
+          "type": "string",
+          "description": "Text that describes changes that have been made in the course"
+        },
+        "analysisName": {
+          "type": "string",
+          "description": "Analysis name"
+        },
+        "applicationCodes": {
+          "type": "string",
+          "description": "Application code(s) used in analysis"
+        },
+        "courseCode": {
+          "type": "string",
+          "description": "Course code for the course that is connected to the analysis"
+        },
+        "endDate": {
+          "type": "string",
+          "description": "End date for round(s) that semester"
+        },
+        "examinationRounds": {
+          "type": "string",
+          "description": "Examinations rounds for the course and semester"
+        },
+        "examiners": {
+          "type": "string",
+          "description": "Examiner(s) for the course that semester"
+        },
+        "gradingDistribution": {
+          "type": "object",
+          "description": "Grading distribution for reported results"
+        },
+        "id": {
+          "type": "string",
+          "description": "Id for round analysis. Same as ladokUID."
+        },
+        "ladokUIDs": {
+          "type": "array",
+          "description": "The UIDs collected from Ladok",
+          "items": { "type": "string" }
+        },
+        "programmeCodes": {
+          "type": "string",
+          "description": "Programmes that are mandatory"
+        },
+        "registeredStudents": {
+          "type": "string",
+          "description": "Number of registered students for round(s) that semester"
+        },
+        "responsibles": {
+          "type": "string",
+          "description": "Responsible(s) for the course that semester"
+        },
+        "semester": {
+          "type": "string",
+          "description": "Course semester for analysis"
+        },
+        "startDate": {
+          "type": "string",
+          "description": "Start date for round(s) that semester"
+        },
+        "totalReportedResults": {
+          "type": "string",
+          "description": "Number of total reported results"
+        }
+      },
+      "example": {
+        "_id": "ObjectId(6711178a1353f5e3af556077)",
+        "alterationText": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras cursus vel urna vel scelerisque. Integer erat risus, rutrum vitae vestibulum et, condimentum vitae nisl.",
+        "analysisName": "XYZ ( Startdatum 2021-02-01, Svenska ) ",
+        "applicationCodes": "1, 2, 3",
+        "courseCode": "XYZ123",
+        "endDate": "2021-05-01",
+        "examinationRounds": "",
+        "examiners": "xyz",
+        "gradingDistribution": {
+          "A": 0,
+          "B": 0,
+          "C": 0,
+          "D": 0,
+          "E": 0,
+          "FX": 0,
+          "F": 0
+        },
+        "id": "aa485652-148f-11ec-82a8-0242ac130003",
+        "ladokUIDs": ["aa485652-148f-11ec-82a8-0242ac130003"],
+        "programmeCodes": "XYZ",
+        "registeredStudents": "2",
+        "responsibles": "xyz",
+        "semester": "20211",
+        "startDate": "2021-02-01",
+        "totalReportedResults": "0"
       }
     },
     "UsedRoundsForCourseAndSemester": {

--- a/swagger.json
+++ b/swagger.json
@@ -369,11 +369,11 @@
         ]
       }
     },
-    "/v1/kursinfoadminCourseAnalysisList/{courseCode}": {
+    "/v1/adminWebCourseAnalysisList/{courseCode}": {
       "get": {
-        "operationId": "getKursinfoadminAnalysisListByCourseCode",
+        "operationId": "getAdminWebAnalysisListByCourseCode",
         "summary": "Get a list of analyses for a course",
-        "description": "Get a list of analyses for a course round published in Kursinfoadmin Tool",
+        "description": "Get a list of analyses for a course round published in the old analysis admin tool \"Kursanalys och kursdata\" previously found in kursutveckling-admin-web.",
         "parameters": [
           {
             "name": "courseCode",

--- a/test/unit/roundAnalysisCtrl.test.js
+++ b/test/unit/roundAnalysisCtrl.test.js
@@ -22,6 +22,16 @@ jest.mock('../../server/lib/database', () => {
     },
     fetchAllRoundAnalysisByCourseCode: jest.fn(),
     fetchAllPublishedRoundAnalysisBySemester: jest.fn(),
+    fetchAllCanvasRoundAnalysesByCourseCode(courseCode) {
+      return new Promise((resolve, reject) => {
+        resolve({ status: 201 })
+      })
+    },
+    fetchAllKursinfoadminRoundAnalysesByCourseCode(courseCode) {
+      return new Promise((resolve, reject) => {
+        resolve({ status: 201 })
+      })
+    },
   }
 })
 jest.mock('../../server/configuration', () => {
@@ -135,6 +145,22 @@ describe('Test functions of roundAnalysisCtrl.js', () => {
     const req = buildReq({ params: { courseCode: 'ef1111', semester: '20192' } })
     const res = buildRes()
     const response = await getUsedRounds(req, res)
+    expect(res.json).toHaveBeenCalledTimes(1)
+  })
+
+  test('getCanvasAnalysisListByCourseCode', async () => {
+    const { getCanvasAnalysisListByCourseCode } = require('../../server/controllers/roundAnalysisCtrl')
+    const req = buildReq({ params: { courseCode: 'ef1111' } })
+    const res = buildRes()
+    const response = await getCanvasAnalysisListByCourseCode(req, res)
+    expect(res.json).toHaveBeenCalledTimes(1)
+  })
+
+  test('getKursinfoadminAnalysisListByCourseCode', async () => {
+    const { getKursinfoadminAnalysisListByCourseCode } = require('../../server/controllers/roundAnalysisCtrl')
+    const req = buildReq({ params: { courseCode: 'ef1111' } })
+    const res = buildRes()
+    const response = await getKursinfoadminAnalysisListByCourseCode(req, res)
     expect(res.json).toHaveBeenCalledTimes(1)
   })
 })

--- a/test/unit/roundAnalysisCtrl.test.js
+++ b/test/unit/roundAnalysisCtrl.test.js
@@ -22,12 +22,12 @@ jest.mock('../../server/lib/database', () => {
     },
     fetchAllRoundAnalysisByCourseCode: jest.fn(),
     fetchAllPublishedRoundAnalysisBySemester: jest.fn(),
-    fetchAllCanvasRoundAnalysesByCourseCode(courseCode) {
+    fetchPublishedCanvasRoundAnalysesByCourseCode(courseCode) {
       return new Promise((resolve, reject) => {
         resolve({ status: 201 })
       })
     },
-    fetchAllKursinfoadminRoundAnalysesByCourseCode(courseCode) {
+    fetchPublishedAdminWebRoundAnalysesByCourseCode(courseCode) {
       return new Promise((resolve, reject) => {
         resolve({ status: 201 })
       })
@@ -156,11 +156,11 @@ describe('Test functions of roundAnalysisCtrl.js', () => {
     expect(res.json).toHaveBeenCalledTimes(1)
   })
 
-  test('getKursinfoadminAnalysisListByCourseCode', async () => {
-    const { getKursinfoadminAnalysisListByCourseCode } = require('../../server/controllers/roundAnalysisCtrl')
+  test('getAdminWebAnalysisListByCourseCode', async () => {
+    const { getAdminWebAnalysisListByCourseCode } = require('../../server/controllers/roundAnalysisCtrl')
     const req = buildReq({ params: { courseCode: 'ef1111' } })
     const res = buildRes()
-    const response = await getKursinfoadminAnalysisListByCourseCode(req, res)
+    const response = await getAdminWebAnalysisListByCourseCode(req, res)
     expect(res.json).toHaveBeenCalledTimes(1)
   })
 })


### PR DESCRIPTION
PR with added endpoints to fetch course round analyses depending on source (`kursinfoadmin` or `canvas`)